### PR TITLE
[Feature] - Edit Notes

### DIFF
--- a/src/components/stickers/editor.tsx
+++ b/src/components/stickers/editor.tsx
@@ -1,0 +1,78 @@
+// Libs
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { observer } from 'mobx-react-lite';
+
+// Store
+import { useStore } from '../../models/root';
+
+interface ContainerProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface InputProps {
+  fontSize: number;
+}
+
+const Container = styled.div<ContainerProps>`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: ${props => props.y}px;
+  left: ${props => props.x}px;
+  width: ${props => props.width}px;
+  height: ${props => props.height}px;
+  text-align: center;
+  background: ${props => props.color};
+  z-index: 10;
+`;
+
+const Text = styled.input<InputProps>`
+  width: 100%;
+  height: 100%;
+  border: none;
+  outline: none;
+  color: #505050;
+  text-align: center;
+  font: 400 ${props => props.fontSize}px 'Montserrat', sans-serif;
+  background: none;
+`;
+
+const Editor = observer(() => {
+  const { boardStore, stickersStore } = useStore();
+  const { editableSticker } = stickersStore;
+
+
+  const sticker = stickersStore.stickers.get(editableSticker.id);
+
+  if (!sticker) return null;
+
+  return (
+    <Container
+      x={editableSticker.x}
+      y={editableSticker.y}
+      width={sticker.width * boardStore.boardBounds.scaleX}
+      height={sticker.height * boardStore.boardBounds.scaleY}
+      color={sticker.fill}
+    >
+      <Text
+        value={sticker.text}
+        fontSize={20 * boardStore.boardBounds.scaleX}
+        onChange={(e) => {
+          stickersStore.updateStickerText({
+            id: editableSticker.id,
+            text: e.target.value,
+          })
+        }}
+        autoFocus
+      />
+    </Container>
+  )
+
+});
+
+export default Editor;

--- a/src/components/stickers/note.tsx
+++ b/src/components/stickers/note.tsx
@@ -11,6 +11,32 @@ interface NoteProps {
 const Note = observer((props: NoteProps) => {
   const { boardStore, stickersStore } = useStore();
 
+  const handleClick = (e) => {
+    e.cancelBubble = true;
+
+    const pos = e.target.parent.getAbsolutePosition(); // Get the absolute position of the group, by defaukt the text element will be the target
+
+    stickersStore.updateSelectedStickers([{
+      type: 'select',
+      id: props.id,
+      ...pos,
+    }]);
+  };
+
+  const handleDoubleClick = (e) => {
+    e.cancelBubble = true;
+
+    const attrs = stickersStore.stickers.get(props.id);
+
+    const pos = e.target.parent.getAbsolutePosition(); // Get the absolute position of the group, by defaukt the text element will be the target
+
+    stickersStore.setEditableSticker({
+      id: props.id,
+      text: attrs?.text,
+      ...pos,
+    });
+  };
+
   const handleDragStart = (e) => {
     e.cancelBubble = true;
   };
@@ -26,7 +52,7 @@ const Note = observer((props: NoteProps) => {
       x: ((e.target.getAbsolutePosition().x - boardStore.boardBounds.x)
         / boardStore.boardBounds.scaleX),
       y: ((e.target.getAbsolutePosition().y - boardStore.boardBounds.y)
-      / boardStore.boardBounds.scaleY)
+        / boardStore.boardBounds.scaleY)
     };
 
     stickersStore.updateStickerPosition({
@@ -49,6 +75,8 @@ const Note = observer((props: NoteProps) => {
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}
       onDragEnd={handleDragEnd}
+      onClick={handleClick}
+      onDblClick={handleDoubleClick}
     >
       <Rect
         x={0}
@@ -63,6 +91,7 @@ const Note = observer((props: NoteProps) => {
         height={attrs.height}
         text={attrs.text}
         fontSize={20}
+        fill='#505050'
         fontFamily='Montserrat'
         align='center'
         verticalAlign='middle'

--- a/src/components/toolbar/index.tsx
+++ b/src/components/toolbar/index.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { useStore } from '../../models/root';
 
 import note from '../../assets/icons/note.svg';
-import emoji from '../../assets/icons/emoji.svg';
+// import emoji from '../../assets/icons/emoji.svg';
 import picture from '../../assets/icons/picture.svg';
 import draw from '../../assets/icons/draw.svg';
 
@@ -57,13 +57,13 @@ const Toolbar = observer(() => {
       >
         <Icon src={note} />
       </Option>
-      <Option
+      {/* <Option
          onClick={() => {
           boardStore.setStickerMode('emoji');
         }}
       >
         <Icon src={emoji} />
-      </Option>
+      </Option> */}
       <Option
          onClick={() => {
           boardStore.setStickerMode('image');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,7 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  <App />
 )

--- a/src/models/stickers.ts
+++ b/src/models/stickers.ts
@@ -1,4 +1,4 @@
-import { types, Instance } from 'mobx-state-tree';
+import { types, Instance, cast } from 'mobx-state-tree';
 
 export const StickerModel = types.model('Sticker', {
   id: types.identifier,
@@ -11,14 +11,39 @@ export const StickerModel = types.model('Sticker', {
   fill: types.string,
 });
 
+const SelectedStickerModel = types.model('SelectedStickerModel', {
+  type: types.string,
+  id: types.string,
+  x: types.number,
+  y: types.number,
+});
+
+const EditableStickerModel = types.model('EditableSticker', {
+  id: types.string,
+  x: types.number,
+  y: types.number,
+  text: types.string,
+});
+
 type StickerType = Instance<typeof StickerModel>;
+type SelectedStickerType = Instance<typeof SelectedStickerModel>;
+type EditableStickerType = Instance<typeof EditableStickerModel>
 
 export const initialState = {
+  editableSticker: {
+    id: '',
+    x: 0,
+    y: 0,
+    text: ''
+  },
+  selectedStickers: [],
   stickers: {}
 };
 
 export const StickersModel = types
-  .model("StickersStore", {
+  .model('StickersStore', {
+    editableSticker: EditableStickerModel,
+    selectedStickers: types.array(SelectedStickerModel),
     stickers: types.map(StickerModel)
   })
   .views((self) => ({
@@ -43,6 +68,22 @@ export const StickersModel = types
             ...newAttrs
           });
         }
+      },
+      updateStickerText(newAttrs: { id: string, text: string}) {
+        const reference = self.stickers.get(newAttrs.id);
+
+        if (reference) {
+          self.stickers.put({
+            ...reference,
+            ...newAttrs
+          });
+        }
+      },
+      updateSelectedStickers(selectedStickers: SelectedStickerType[]) {
+        self.selectedStickers = cast(selectedStickers);
+      },
+      setEditableSticker(editableSticker: EditableStickerType) {
+        self.editableSticker = editableSticker;
       }
     }
   });

--- a/src/pages/whiteboard/index.tsx
+++ b/src/pages/whiteboard/index.tsx
@@ -11,6 +11,7 @@ import Grid from './grid';
 
 import Toolbar from '../../components/toolbar';
 import Note from '../../components/stickers/note';
+import Editor from '../../components/stickers/editor';
 
 // Images
 import note from '../../assets/icons/note.png';
@@ -28,6 +29,15 @@ const Whiteboard = observer(() => {
 
   const handleDragStart = (e) => {
     e.evt.stopPropagation();
+
+    // Make sure to deselect any object on move
+    stickersStore.setEditableSticker({
+      id: '',
+      text: '',
+      x: 0,
+      y: 0,
+    });
+    stickersStore.updateSelectedStickers([]);
   };
 
   const handleDragMove = (e) => {
@@ -51,6 +61,16 @@ const Whiteboard = observer(() => {
 
   const handleWheel = (e) => {
     e.evt.preventDefault();
+
+    // Make sure to deselect any object on zoom
+    stickersStore.setEditableSticker({
+      id: '',
+      text: '',
+      x: 0,
+      y: 0,
+    });
+    stickersStore.updateSelectedStickers([]);
+
     const stage = e.target.getStage();
     const oldScale = stage.scaleX();
 
@@ -102,6 +122,14 @@ const Whiteboard = observer(() => {
       stickersStore.addSticker(newSticker);
       boardStore.setStickerMode('none');
     }
+
+    stickersStore.setEditableSticker({
+      id: '',
+      text: '',
+      x: 0,
+      y: 0,
+    });
+    stickersStore.updateSelectedStickers([]);
   }
 
   const boundFunc = (pos: { x: number, y: number }, scale: number) => {
@@ -164,6 +192,7 @@ const Whiteboard = observer(() => {
   }
 
   const { boardBounds } = boardStore;
+  const { editableSticker } = stickersStore;
 
   return (
     <div
@@ -197,6 +226,9 @@ const Whiteboard = observer(() => {
         </Layer>
       </Stage>
       <Toolbar />
+      {editableSticker.id && (
+        <Editor />
+      )}
     </div>
   );
 })


### PR DESCRIPTION
Enabling edition on notes through an Input layered on top of the sticker when user double click any note.

Stage pan/zoom methods clean editable stickers on mobx to make sure the editor does not float around on screen
